### PR TITLE
Bugfix: Some preprocess function not found.

### DIFF
--- a/stable_projects/preprocessing/CBIG_fMRI_Preproc2016/CBIG_preproc_FCmetrics_wrapper.csh
+++ b/stable_projects/preprocessing/CBIG_fMRI_Preproc2016/CBIG_preproc_FCmetrics_wrapper.csh
@@ -232,6 +232,7 @@ if ( $Pearson_r == 1 ) then
 		echo "[FC metrics]: The output file $output_dir/${output_prefix}_all2all.mat already exists. Skip ..." |& tee -a $LF
 	else
 		set cmd = ( $MATLAB -nodesktop -nodisplay -nosplash -r '"' 'addpath(genpath('"'"${root_dir}'/utilities'"'"'))'; )
+		set cmd = ($cmd 'addpath(genpath('"'"${CBIG_CODE_DIR}'/utilities/matlab'"'"'))'; )
 		set cmd = ($cmd CBIG_preproc_FCmetrics "'"$lh_cortical_ROIs_file"'" "'"$rh_cortical_ROIs_file"'" )
 		set cmd = ($cmd "'"$subcortex_func_vol"'" "'"$lh_surf_data_list"'" "'"$rh_surf_data_list"'" "'"$vol_data_list"'")
 		set cmd = ($cmd  "'"$discard_frames_list"'" "'"Pearson_r"'" "'"$output_dir"'" "'"$output_prefix"'"; exit; '"' );

--- a/stable_projects/preprocessing/CBIG_fMRI_Preproc2016/utilities/CBIG_preproc_DVARS_FDRMS_Correlation.m
+++ b/stable_projects/preprocessing/CBIG_fMRI_Preproc2016/utilities/CBIG_preproc_DVARS_FDRMS_Correlation.m
@@ -27,7 +27,7 @@ fd = csvread(FDRMS_file);
 dvars = csvread(DVARS_file);
 
 %% Compute the correlation, discard the first frame
-coe = CBIG_corr(fd(2:end), dvars(2:end));
+coe = CBIG_preproc_corr_matrix(fd(2:end), dvars(2:end));
 
 %% Plot and save the figure
 figure;


### PR DESCRIPTION
Modify: Change a function call in file `CBIG_preproc_DVARS_FDRMS_Correlation.m` to solve not defined function error.
Modify: Add a matlab path in file `CBIG_preproc_FCmetrics_wrapper.csh` to solve function not found error.